### PR TITLE
Replaced filtering on obsolete KSPI partmofules by current KSPIE partmodules

### DIFF
--- a/GameData/000_FilterExtensions_Configs/SubCategories_ISRU.cfg
+++ b/GameData/000_FilterExtensions_Configs/SubCategories_ISRU.cfg
@@ -7,7 +7,7 @@ SUBCATEGORY
 		CHECK
 		{
 			type = moduleName
-			value = FNModuleResourceExtraction, ISRUScoop, ModuleResourceHarvester, ModuleAsteroidDrill, AsteroidMassConverter
+			value = FNModuleResourceExtraction, AntimatterCollector, RegolithCollector, SolarWindCollector, UniversalCrustExtractor, ModuleResourceHarvester, ModuleAsteroidDrill, AsteroidMassConverter
 		}
 	}
 }
@@ -20,7 +20,7 @@ SUBCATEGORY
 		CHECK
 		{
 			type = moduleName
-			value = ModuleResourceConverter, TacGenericConverter, InterstellarRefinery, KethaneConverter, KolonyConverter, HangarResourceConverter
+			value = ModuleResourceConverter, TacGenericConverter, InterstellarRefineryController, KethaneConverter, KolonyConverter, HangarResourceConverter
 		}
 		CHECK
 		{


### PR DESCRIPTION
The referenced KSPI partmodules are quite obsolete and have been replaced by and substituted by several other partmodules specifically for  KSPIE