### PR TITLE
New CheckNodes for Thrust, ISP Atmo & Vac

### DIFF
--- a/FilterExtension/ConfigNodes/CheckNodes/CheckNodeFactory.cs
+++ b/FilterExtension/ConfigNodes/CheckNodes/CheckNodeFactory.cs
@@ -39,6 +39,12 @@
                     return new CheckPropellant(node);
                 case CheckEngineType.ID:
                     return new CheckEngineType(node);
+				case CheckThrust.ID:
+					return new CheckThrust(node);
+                case CheckISP_Atmo.ID:
+                    return new CheckISP_Atmo(node);
+                case CheckISP_Vac.ID:
+                    return new CheckISP_Vac(node);
                 case CheckGroup.ID:
                     return new CheckGroup(node);
                 case CheckSize.ID:

--- a/FilterExtension/ConfigNodes/CheckNodes/CheckNodeNumeric.cs
+++ b/FilterExtension/ConfigNodes/CheckNodes/CheckNodeNumeric.cs
@@ -128,4 +128,49 @@ namespace FilterExtensions.ConfigNodes.CheckNodes
             return Invert ^ PartType.CheckTemperature(part, Values, Equality);
         }
     }
+
+	/// <summary>
+	/// checks part engine thrust
+	/// </summary>
+	public class CheckThrust : CheckNodeNumeric
+	{
+		public const string ID = "thrust";
+		public override string CheckID { get => ID; }
+
+		public CheckThrust(ConfigNode node) : base(node) { }
+		public override bool CheckResult(AvailablePart part, int depth = 0)
+		{
+			return Invert ^ PartType.CheckThrust(part, Values, Equality);
+		}
+	}
+
+	/// <summary>
+	/// checks part engine ISP Atmo
+	/// </summary>
+	public class CheckISP_Atmo : CheckNodeNumeric
+	{
+		public const string ID = "isp_atm";
+		public override string CheckID { get => ID; }
+
+		public CheckISP_Atmo(ConfigNode node) : base(node) { }
+		public override bool CheckResult(AvailablePart part, int depth = 0)
+		{
+			return Invert ^ PartType.CheckISP(part, Values, Equality, false);
+		}
+	}
+
+    /// <summary>
+    /// checks part engine ISP Vac
+    /// </summary>
+    public class CheckISP_Vac : CheckNodeNumeric
+    {
+        public const string ID = "isp_vac";
+        public override string CheckID { get => ID; }
+
+        public CheckISP_Vac(ConfigNode node) : base(node) { }
+        public override bool CheckResult(AvailablePart part, int depth = 0)
+        {
+            return Invert ^ PartType.CheckISP(part, Values, Equality, true);
+        }
+    }
 }

--- a/FilterExtension/Utility/PartType.cs
+++ b/FilterExtension/Utility/PartType.cs
@@ -766,6 +766,101 @@ namespace FilterExtensions.Utility
             return false;
         }
 
+		/// <summary>
+		/// check the thrust of the engine
+		/// </summary>
+		public static bool CheckThrust(AvailablePart part, string[] value, ConfigNodes.CheckNodes.CompareType equality = ConfigNodes.CheckNodes.CompareType.Equals)
+		{
+		    if (!IsEngine(part))
+		    {
+		        return false;
+		    }
+			if (part.partPrefab == null)
+			{
+				return false;
+			}
+		    foreach (var engine in part.partPrefab.Modules.OfType<ModuleEngines>())
+		    {
+		        if (equality == ConfigNodes.CheckNodes.CompareType.Equals)
+		        {
+		            return value.Contains(engine.maxThrust.ToString(), StringComparer.OrdinalIgnoreCase);
+		        }
+		        else
+		        {
+		            if (value.Length > 1)
+		            {
+		                Logger.Log($"Thrust comparisons against multiple values when not using Equals only use the first value. Value list is: {string.Join(", ", value)}", Logger.LogLevel.Warn);
+		            }
+		            if (double.TryParse(value[0], out double d))
+		            {
+		                if (equality == ConfigNodes.CheckNodes.CompareType.GreaterThan && engine.maxThrust > d)
+		                {
+		                    return true;
+		                }
+		                else if (equality == ConfigNodes.CheckNodes.CompareType.LessThan && engine.maxThrust < d)
+		                {
+		                    return true;
+		                }
+		            }
+		        }
+		    }
+			return false;
+		}
+
+		/// <summary>
+		/// check the ISP of the engine
+		/// </summary>
+		public static bool CheckISP(AvailablePart part, string[] value, ConfigNodes.CheckNodes.CompareType equality = ConfigNodes.CheckNodes.CompareType.Equals, bool vacuum = false)
+		{
+		    if (!IsEngine(part))
+		    {
+		        return false;
+		    }
+		    if (part.partPrefab == null)
+		    {
+		        return false;
+		    }
+		    foreach (var engine in part.partPrefab.Modules.OfType<ModuleEngines>())
+		    {
+		        float atm = engine.atmosphereCurve.Evaluate(1);
+		        float vac = engine.atmosphereCurve.Evaluate(0);
+		        
+		        float isp;
+		        if (vacuum)
+		        {
+		            isp = vac;
+		        }
+		        else
+		        {
+		            isp = atm;
+		        }
+		        
+		        if (equality == ConfigNodes.CheckNodes.CompareType.Equals)
+		        {
+		            return value.Contains(isp.ToString(), StringComparer.OrdinalIgnoreCase);
+		        }
+		        else
+		        {
+		            if (value.Length > 1)
+		            {
+		                Logger.Log($"ISP comparisons against multiple values when not using Equals only use the first value. Value list is: {string.Join(", ", value)}", Logger.LogLevel.Warn);
+		            }
+		            if (double.TryParse(value[0], out double d))
+		            {
+		                if (equality == ConfigNodes.CheckNodes.CompareType.GreaterThan && isp > d)
+		                {
+		                    return true;
+		                }
+		                else if (equality == ConfigNodes.CheckNodes.CompareType.LessThan && isp < d)
+		                {
+		                    return true;
+		                }
+		            }
+		        }
+		    }
+		    return false;
+		}
+
         /// <summary>
         /// bulkhead profiles used to id part shapes for stock editor. parts with no profiles get dumped in srf
         /// </summary>

--- a/buildRelease.sh
+++ b/buildRelease.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+[ "$3" != "Release" ] || exit
+
+DEV="/home/cameron/src/FilterExtension"
+
+GAMEDIR="000_FilterExtensions"
+GAMEDIR2="000_FilterExtensions_Configs"
+LICENSE="License.txt"
+README="ReadMe.txt"
+
+RELEASEDIR="$DEV/release"
+mkdir -p "$RELEASEDIR"
+
+cp "$1$2" "$DEV/GameData/$GAMEDIR/Plugins/"
+
+cp "$DEV/FilterExtension.version" "$DEV/GameData/$GAMEDIR/"
+# cp "$DEV/../MiniAVC.dll" "$DEV/GameData/$GAMEDIR" # ??
+
+cp "$DEV/$LICENSE" "$DEV/GameData/$GAMEDIR"
+cp "$DEV/$README" "$DEV/GameData/$GAMEDIR"
+
+VERSIONFILE="$DEV/FilterExtension.version"
+VMA=`jq ".VERSION.MAJOR" $VERSIONFILE`
+VMI=`jq ".VERSION.MINOR" $VERSIONFILE`
+PA=`jq ".VERSION.PATCH" $VERSIONFILE`
+BU=`jq ".VERSION.BUILD" $VERSIONFILE`
+VERSION="$VMA.$VMI.$PA.$BU"
+
+echo "Version: $VERSION"
+
+cd "$DEV"
+rm "$RELEASEDIR/$GAMEDIR-$VERSION.zip"
+zip -r "$RELEASEDIR/$GAMEDIR-$VERSION.zip" "GameData"

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+DEV="/home/cameron/src/FilterExtension"
+KSP="/mnt/games/KSPDev"
+
+GAMEDIR="000_FilterExtensions"
+GAMEDIR2="000_FilterExtensions_Configs"
+GAMEDATA="GameData/"
+
+cp "$1$2" "$DEV/GameData/$GAMEDIR/Plugins"
+cp "$DEV/FilterExtension.version" "$DEV/GameData/$GAMEDIR/"
+
+cp -r "$DEV/$GAMEDATA/$GAMEDIR" "$KSP/GameData/"
+cp -r "$DEV/$GAMEDATA/$GAMEDIR2" "$KSP/GameData/"


### PR DESCRIPTION
I've been looking for ways to solve what I see as a problem with the whole Realism Overhaul suite: so many engines! It's painful to look through the engines with the existing sort methods to find something that fits your needs.

So, I've added three new Check nodes for this purpose: Thrust and ISP (Atmospheric and Vacuum). They extend numeric nodes so it's possible to categorize engines into ranges. Thrust checks the maximum thrust of the engine, and the ISP variants check ISP at full/no atmosphere. For example, here's some simple subcategories using them. I set the values in order to prevent an engine from totally being excluded if it had a very even/round thrust number, since this config simply checks >/< and not >=/<

I tested this on a full RO install and a stock/FE install, and everything appears to be working. At this point, some of the numeric comparison functions could use some refactoring into a generalized solution, and I'm not sure how the tests work so I didn't add any.

```

SUBCATEGORY
{
	name = Very Low Thrust
	icon = stockIcon_engine
	FILTER
	{
		CHECK
		{
			type = thrust
			value = 39.95
			equality = LessThan
		}
	}
}
SUBCATEGORY
{
	name = Low Thrust
	icon = stockIcon_engine
	FILTER
	{
		CHECK
		{
			type = thrust
			value = 39.95
			equality = GreaterThan
		}
		CHECK
		{
			type = thrust
			value = 99.95
			equality = LessThan
		}
	}
}
SUBCATEGORY
{
	name = Medium Thrust
	icon = stockIcon_engine
	FILTER
	{
		CHECK
		{
			type = thrust
			value = 99.95
			equality = GreaterThan
		}
		CHECK
		{
			type = thrust
			value = 499.95
			equality = LessThan
		}
	}
}
SUBCATEGORY
{
	name = High Thrust
	icon = stockIcon_engine
	FILTER
	{
		CHECK
		{
			type = thrust
			value = 499.95
			equality = GreaterThan
		}
		CHECK
		{
			type = thrust
			value = 4999.95
			equality = LessThan
		}
	}
}
SUBCATEGORY
{
	name = Huge Thrust
	icon = stockIcon_engine
	FILTER
	{
		CHECK
		{
			type = thrust
			value = 4999.95
			equality = GreaterThan
		}
	}
}
SUBCATEGORY
{
	name = Atmospheric Thrust
	icon = stockIcon_engine
	FILTER
	{
		CHECK
		{
			type = isp_atm
			value = 300
			equality = GreaterThan
		}
	}
}
SUBCATEGORY
{
	name = Vacuum Thrust
	icon = stockIcon_engine
	FILTER
	{
		CHECK
		{
			type = isp_vac
			value = 300
			equality = GreaterThan
		}
	}
}
```