### PR TITLE
From electrics to unmanned tech again

### DIFF
--- a/GameData/zFinal_FilterExtensions/zzz_RemoteTechAddMissingModuleSPUPassive.cfg
+++ b/GameData/zFinal_FilterExtensions/zzz_RemoteTechAddMissingModuleSPUPassive.cfg
@@ -35,9 +35,9 @@
 		{
 			UPGRADE
 			{
-				name__ = GD_RT_electrics
+				name__ = GD_RT_unmannedTech
 				description__ = Probe cores are now remote controllable
-				techRequired__ = electrics
+				techRequired__ = unmannedTech
 				moduleIsEnabled = true
 			}
 		}
@@ -51,9 +51,9 @@
 		{
 			UPGRADE
 			{
-				name__ = GD_RT_electrics
+				name__ = GD_RT_unmannedTech
 				description__ = Probe cores are now remote controllable
-				techRequired__ = electrics
+				techRequired__ = unmannedTech
 				moduleIsEnabled = true
 			}
 		}
@@ -75,9 +75,9 @@
 		{
 			UPGRADE
 			{
-				name__ = GD_RT_electrics
+				name__ = GD_RT_unmannedTech
 				description__ = Probe cores are now remote controllable
-				techRequired__ = electrics
+				techRequired__ = unmannedTech
 				moduleIsEnabled = true
 			}
 		}
@@ -91,9 +91,9 @@
 		{
 			UPGRADE
 			{
-				name__ = GD_RT_electrics
+				name__ = GD_RT_unmannedTech
 				description__ = Probe cores are now remote controllable
-				techRequired__ = electrics
+				techRequired__ = unmannedTech
 				moduleIsEnabled = true
 			}
 		}
@@ -115,9 +115,9 @@
 		{
 			UPGRADE
 			{
-				name__ = GD_RT_electrics
+				name__ = GD_RT_unmannedTech
 				description__ = Probe cores are now remote controllable
-				techRequired__ = electrics
+				techRequired__ = unmannedTech
 				moduleIsEnabled = true
 			}
 		}
@@ -132,9 +132,9 @@
 		{
 			UPGRADE
 			{
-				name__ = GD_RT_electrics
+				name__ = GD_RT_unmannedTech
 				description__ = Probe cores are now remote controllable
-				techRequired__ = electrics
+				techRequired__ = unmannedTech
 				moduleIsEnabled = true
 			}
 		}
@@ -156,9 +156,9 @@
 		{
 			UPGRADE
 			{
-				name__ = GD_RT_electrics
+				name__ = GD_RT_unmannedTech
 				description__ = Probe cores are now remote controllable
-				techRequired__ = electrics
+				techRequired__ = unmannedTech
 				moduleIsEnabled = true
 			}
 		}
@@ -173,9 +173,9 @@
 		{
 			UPGRADE
 			{
-				name__ = GD_RT_electrics
+				name__ = GD_RT_unmannedTech
 				description__ = Probe cores are now remote controllable
-				techRequired__ = electrics
+				techRequired__ = unmannedTech
 				moduleIsEnabled = true
 			}
 		}
@@ -203,9 +203,9 @@
 		{
 			UPGRADE
 			{
-				name__ = GD_RT_electrics
+				name__ = GD_RT_unmannedTech
 				description__ = Probe cores are now remote controllable
-				techRequired__ = electrics
+				techRequired__ = unmannedTech
 				moduleIsEnabled = true
 			}
 		}
@@ -220,9 +220,9 @@
 		{
 			UPGRADE
 			{
-				name__ = GD_RT_electrics
+				name__ = GD_RT_unmannedTech
 				description__ = Probe cores are now remote controllable
-				techRequired__ = electrics
+				techRequired__ = unmannedTech
 				moduleIsEnabled = true
 			}
 		}
@@ -249,9 +249,9 @@
 		{
 			UPGRADE
 			{
-				name__ = GD_RT_electrics
+				name__ = GD_RT_unmannedTech
 				description__ = Probe cores are now remote controllable
-				techRequired__ = electrics
+				techRequired__ = unmannedTech
 				moduleIsEnabled = true
 			}
 		}
@@ -266,9 +266,9 @@
 		{
 			UPGRADE
 			{
-				name__ = GD_RT_electrics
+				name__ = GD_RT_unmannedTech
 				description__ = Probe cores are now remote controllable
-				techRequired__ = electrics
+				techRequired__ = unmannedTech
 				moduleIsEnabled = true
 			}
 		}
@@ -294,9 +294,9 @@
 		{
 			UPGRADE
 			{
-				name__ = GD_RT_electrics
+				name__ = GD_RT_unmannedTech
 				description__ = Probe cores are now remote controllable
-				techRequired__ = electrics
+				techRequired__ = unmannedTech
 				moduleIsEnabled = true
 			}
 		}
@@ -311,9 +311,9 @@
 		{
 			UPGRADE
 			{
-				name__ = GD_RT_electrics
+				name__ = GD_RT_unmannedTech
 				description__ = Probe cores are now remote controllable
-				techRequired__ = electrics
+				techRequired__ = unmannedTech
 				moduleIsEnabled = true
 			}
 		}
@@ -338,9 +338,9 @@
 		{
 			UPGRADE
 			{
-				name__ = GD_RT_electrics
+				name__ = GD_RT_unmannedTech
 				description__ = Probe cores are now remote controllable
-				techRequired__ = electrics
+				techRequired__ = unmannedTech
 				moduleIsEnabled = true
 			}
 		}
@@ -355,9 +355,9 @@
 		{
 			UPGRADE
 			{
-				name__ = GD_RT_electrics
+				name__ = GD_RT_unmannedTech
 				description__ = Probe cores are now remote controllable
-				techRequired__ = electrics
+				techRequired__ = unmannedTech
 				moduleIsEnabled = true
 			}
 		}
@@ -565,9 +565,9 @@
 
 PARTUPGRADE
 {
-	name = GD_RT_electrics
-	partIcon = GD.RT.electrics
-	techRequired = electrics
+	name = GD_RT_unmannedTech
+	partIcon = GD.RT.unmannedTech
+	techRequired = unmannedTech
 	entryCost = 2000
 	cost = 0 // for display only; all parts implementing this will need a PartStatsUpgradeModule with cost = this.
 
@@ -593,7 +593,7 @@ PARTUPGRADE
 
 PART
 {
-	name = GD_RT_electrics
+	name = GD_RT_unmannedTech
 	module = Part
 	author = Gordon Dry (used under permission of Allis Tauri)
 	RSSROConfig = true
@@ -701,9 +701,9 @@ PART
 		{
 			UPGRADE
 			{
-				name__ = GD_RT_electrics
+				name__ = GD_RT_unmannedTech
 				description__ = Probe cores are now remote controllable
-				techRequired__ = electrics
+				techRequired__ = unmannedTech
 				moduleIsEnabled = true
 			}
 		}
@@ -728,9 +728,9 @@ PART
 		{
 			UPGRADE
 			{
-				name__ = GD_RT_electrics
+				name__ = GD_RT_unmannedTech
 				description__ = Probe cores are now remote controllable
-				techRequired__ = electrics
+				techRequired__ = unmannedTech
 				moduleIsEnabled = true
 			}
 		}
@@ -749,9 +749,9 @@ PART
 		{
 			UPGRADE
 			{
-				name__ = GD_RT_electrics
+				name__ = GD_RT_unmannedTech
 				description__ = Probe cores are now remote controllable
-				techRequired__ = electrics
+				techRequired__ = unmannedTech
 				moduleIsEnabled = true
 			}
 		}
@@ -776,9 +776,9 @@ PART
 		{
 			UPGRADE
 			{
-				name__ = GD_RT_electrics
+				name__ = GD_RT_unmannedTech
 				description__ = Probe cores are now remote controllable
-				techRequired__ = electrics
+				techRequired__ = unmannedTech
 				moduleIsEnabled = true
 			}
 		}


### PR DESCRIPTION
Changing the necessary tech tree unlock for "Probe cores are now remote controllable" from electrics to unmannedTech.