### PR TITLE
Update Mod_ProceduralParts.cfg

### DIFF
--- a/GameData/000_FilterExtensions_Configs/Default/Mod_ProceduralParts.cfg
+++ b/GameData/000_FilterExtensions_Configs/Default/Mod_ProceduralParts.cfg
@@ -23,5 +23,6 @@ CATEGORY:NEEDS[ProceduralParts]
 		list = 5,Aerodynamics
 		list = 6,Thermal
 		list = 7,Electrical
+		list = 8,Utility
 	}
 }


### PR DESCRIPTION
Add a "Utility" subcategory to allow the life support tanks to be displayed when selecting the Procedural Parts mod icon.