### PR TITLE
Update SubCategories_Electrical.cfg (KSP-IE quick fix)

### DIFF
--- a/GameData/000_FilterExtensions_Configs/SubCategories_Electrical.cfg
+++ b/GameData/000_FilterExtensions_Configs/SubCategories_Electrical.cfg
@@ -63,10 +63,16 @@ SUBCATEGORY
 			type = resource
 			value = ElectricCharge, StoredCharge
 		}
+		CHECK:NEEDS[WarpPlugin]
+		{
+			type = field
+			value = ElectricCharge, maxAmount, 0.001
+			invert = true
+		}
 		CHECK
 		{
 			type = moduleName
-			value = ModuleCommand, ModuleEngines, ModuleEnginesFX, REGO_ModuleResourceConverter, ModuleGenerator, FNGenerator, ModuleRadioisotopeGenerator
+			value = ModuleCommand, ModuleEngines, ModuleEnginesFX, REGO_ModuleResourceConverter, ModuleGenerator, FNGenerator, ModuleRadioisotopeGenerator, ModuleDeployableSolarPanel, ModuleCurvedSolarPanel, KopernicusSolarPanel
 			invert = true
 		}
 	}

--- a/GameData/000_FilterExtensions_Configs/SubCategories_Electrical.cfg
+++ b/GameData/000_FilterExtensions_Configs/SubCategories_Electrical.cfg
@@ -63,7 +63,7 @@ SUBCATEGORY
 			type = resource
 			value = ElectricCharge, StoredCharge
 		}
-		CHECK:NEEDS[WarpPlugin]
+		CHECK:NEEDS[WarpPlugin] // this one does not work as I wanted, so the quick fix below by adding the solar panel modules to the list is needed
 		{
 			type = field
 			value = ElectricCharge, maxAmount, 0.001


### PR DESCRIPTION
see https://forum.kerbalspaceprogram.com/index.php?/topic/168456-18x-filter-extensions-no-localization/&do=findComment&comment=3706171

The problem is that KSP-IE adds a block
```
	RESOURCE
	{
		name = ElectricCharge
		amount = 0
		maxAmount = 0.001
		isTweakable = false
		hideFlow = false
	}
```
to every part with ModuleDeployableSolarPanel.

So does FilterExtensions show all solar panels in the subcategory for "Power Storage".

This change fixes that, although not as I wanted (see forum post).