### PR TITLE
Add custom check for parts that have TechHidden = True

### DIFF
--- a/FilterExtension/Utility/PartType.cs
+++ b/FilterExtension/Utility/PartType.cs
@@ -49,7 +49,11 @@ namespace FilterExtensions.Utility
                     case "purchased":
                         testVal = ResearchAndDevelopment.PartModelPurchased(part);
                         break;
-                }
+ 
+                    case "hidden":
+                        testVal = IsHidden(part);
+                        break;
+               }
                 if (testVal)
                 {
                     return true;
@@ -952,6 +956,14 @@ namespace FilterExtensions.Utility
                 return false;
             }
             return part.partPrefab.attachNodes[0].size != part.partPrefab.attachNodes[1].size;
+        }
+        
+        /// <summary>
+        /// checks if the part is supposed to be hidden (i.e. deprecated)
+        /// </summary>
+        public static bool IsHidden(AvailablePart part)
+        {
+            return part.TechHidden;
         }
 
         public static bool Contains(string[] CheckParams, IEnumerable<string> partParams, bool contains = true, bool exact = false)

--- a/GameData/000_FilterExtensions_Configs/SubCategories_Stock.cfg
+++ b/GameData/000_FilterExtensions_Configs/SubCategories_Stock.cfg
@@ -78,7 +78,7 @@ SUBCATEGORY
 		CHECK
 		{
 			type = category
-			value = XenonGas
+			value = Robotics
 		}
 	}
 }
@@ -234,6 +234,12 @@ SUBCATEGORY
 			type = category
 			value = None
 		}
+		CHECK
+		{
+			type = custom
+			value = hidden
+			invert = true
+		}
 	}
 }
 SUBCATEGORY
@@ -368,6 +374,3 @@ SUBCATEGORY
 		}
 	}
 }
-
-
-


### PR DESCRIPTION
Fully tested with 1.8.1.

These are either deprecated parts, or parts that are forced hidden for whatever reason (i.e. Restock + parts that are modified via patch if Making History is detected).

In particular this will be useful for my MoarFilterExtension mod. I have an update pending for it that takes advantage of this new feature.