### PR TITLE
Add "Eisenhower Astronautics - Stockalike Angara" to Tantares

### DIFF
--- a/GameData/000_FilterExtensions_Configs/Default/Mod_Tantares.cfg
+++ b/GameData/000_FilterExtensions_Configs/Default/Mod_Tantares.cfg
@@ -1,4 +1,4 @@
-CATEGORY:NEEDS[Tantares,!TantaresLV]
+CATEGORY:NEEDS[Tantares,!TantaresLV,!Eisenhower-Astronautics]
 {
 	name = Tantares Space Technologies
 	icon = Tantares
@@ -34,7 +34,7 @@ CATEGORY:NEEDS[Tantares,!TantaresLV]
 	}
 }
 
-CATEGORY:NEEDS[!Tantares,TantaresLV]
+CATEGORY:NEEDS[!Tantares,TantaresLV,!Eisenhower-Astronautics]
 {
 	name = Tantares Space Technologies
 	icon = Tantares
@@ -70,7 +70,7 @@ CATEGORY:NEEDS[!Tantares,TantaresLV]
 	}
 }
 
-CATEGORY:NEEDS[Tantares,TantaresLV]
+CATEGORY:NEEDS[Tantares,TantaresLV,!Eisenhower-Astronautics]
 {
 	name = Tantares Space Technologies
 	icon = Tantares
@@ -83,6 +83,114 @@ CATEGORY:NEEDS[Tantares,TantaresLV]
 		{
 			type = folder
 			value = Tantares,TantaresLV
+		}
+	}
+	
+	SUBCATEGORIES
+	{
+		list = 0,Pods
+		list = 1,Fuel Tanks
+		list = 2,Engines
+		list = 3,Command and Control
+		list = 4,Structural
+		list = 5,Coupling
+		list = 6,Payload
+		list = 7,Aerodynamics
+		list = 8,Ground
+		list = 9,Thermal
+		list = 10,Electrical
+		list = 11,Communications
+		list = 12,Science
+		list = 13,Utility
+		list = 14,Undefined
+	}
+}
+
+CATEGORY:NEEDS[Tantares,!TantaresLV,Eisenhower-Astronautics]
+{
+	name = Tantares Space Technologies
+	icon = Tantares
+	colour = #FFF0F0F0
+	all = true
+	
+	FILTER
+	{
+		CHECK
+		{
+			type = folder
+			value = Tantares,Eisenhower-Astronautics
+		}
+	}
+	
+	SUBCATEGORIES
+	{
+		list = 0,Pods
+		list = 1,Fuel Tanks
+		list = 2,Engines
+		list = 3,Command and Control
+		list = 4,Structural
+		list = 5,Coupling
+		list = 6,Payload
+		list = 7,Aerodynamics
+		list = 8,Ground
+		list = 9,Thermal
+		list = 10,Electrical
+		list = 11,Communications
+		list = 12,Science
+		list = 13,Utility
+		list = 14,Undefined
+	}
+}
+
+CATEGORY:NEEDS[!Tantares,TantaresLV,Eisenhower-Astronautics]
+{
+	name = Tantares Space Technologies
+	icon = Tantares
+	colour = #FFF0F0F0
+	all = true
+	
+	FILTER
+	{
+		CHECK
+		{
+			type = folder
+			value = TantaresLV,Eisenhower-Astronautics
+		}
+	}
+	
+	SUBCATEGORIES
+	{
+		list = 0,Pods
+		list = 1,Fuel Tanks
+		list = 2,Engines
+		list = 3,Command and Control
+		list = 4,Structural
+		list = 5,Coupling
+		list = 6,Payload
+		list = 7,Aerodynamics
+		list = 8,Ground
+		list = 9,Thermal
+		list = 10,Electrical
+		list = 11,Communications
+		list = 12,Science
+		list = 13,Utility
+		list = 14,Undefined
+	}
+}
+
+CATEGORY:NEEDS[Tantares,TantaresLV,Eisenhower-Astronautics]
+{
+	name = Tantares Space Technologies
+	icon = Tantares
+	colour = #FFF0F0F0
+	all = true
+	
+	FILTER
+	{
+		CHECK
+		{
+			type = folder
+			value = Tantares,TantaresLV,Eisenhower-Astronautics
 		}
 	}
 	


### PR DESCRIPTION
They share the same Wiki, so why not?
The mod itself links to https://github.com/friznit/Unofficial-Tantares-Wiki/wiki/Angara on its OP:
https://forum.kerbalspaceprogram.com/index.php?/topic/196384-111x-eisenhower-astronautics-v110-stockalike-angara/