### PR TITLE
Upload new CFG file for KNES mod

### DIFF
--- a/GameData/000_FilterExtensions_Configs/Default/Mod_KNES.cfg
+++ b/GameData/000_FilterExtensions_Configs/Default/Mod_KNES.cfg
@@ -1,0 +1,35 @@
+CATEGORY:NEEDS[Knes]
+{
+	name = Knes
+	icon = KNES
+	colour = #FFF0F0F0
+	all = true
+	
+	FILTER
+	{
+		CHECK
+		{
+			type = folder
+			value = Knes
+		}
+	}
+	
+	SUBCATEGORIES
+	{
+		list = 0,Pods
+		list = 1,Fuel Tanks
+		list = 2,Engines
+		list = 3,Command and Control
+		list = 4,Structural
+		list = 5,Coupling
+		list = 6,Payload
+		list = 7,Aerodynamics
+		list = 8,Ground
+		list = 9,Thermal
+		list = 10,Electrical
+		list = 11,Communications
+		list = 12,Science
+		list = 13,Utility
+		list = 14,Undefined
+	}
+}


### PR DESCRIPTION
Added .CFG file "Mod_KNES.CFG" to \000_FilterExtensions\Default to have KNES listed on it's own in the Manufacturers icon.